### PR TITLE
Support versions in asset names

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,9 +99,9 @@ You can use any of the following variables in your formula template, and they'll
 |`$DEVEL_ASSET_URL`|Wownload URL of the asset from the latest pre-release.|
 |`$DEVEL_ASSET_SHA256`|SHA256 of the asset from the latest pre-release.|
 
-## URL variables
+## Asset & URL variables
 
-You can use any of the following variables in your URL template, and they'll be substituted for each stable and development release when the tap is regenerated:
+You can use any of the following variables in the `asset` and `url` options, and they'll be substituted for each stable and development release when searching for assets or generating URLs:
 
 |Variable|Description|
 |-|-|

--- a/lib/run.js
+++ b/lib/run.js
@@ -58,7 +58,11 @@ module.exports = async ({ app, context, configName }) => {
 
   if (asset) {
     if (latest) {
-      const stableAsset = latest.assets.find(a => a.name === asset)
+      const assetNameToFind = asset
+        .replace('$VERSION_NUMBER', latest.tag_name.replace(/^v/, ''))
+        .replace('$VERSION', latest.tag_name)
+
+      const stableAsset = latest.assets.find(a => a.name === assetNameToFind)
 
       if (stableAsset) {
         const stableUrl = stableAsset.browser_download_url
@@ -70,7 +74,11 @@ module.exports = async ({ app, context, configName }) => {
     }
 
     if (latestPre) {
-      const develAsset = latestPre.assets.find(a => a.name === asset)
+      const assetNameToFind = asset
+        .replace('$VERSION_NUMBER', latestPre.tag_name.replace(/^v/, ''))
+        .replace('$VERSION', latestPre.tag_name)
+
+      const develAsset = latestPre.assets.find(a => a.name === assetNameToFind)
 
       if (develAsset) {
         const develUrl = develAsset.browser_download_url

--- a/test/fixtures/config.yml
+++ b/test/fixtures/config.yml
@@ -1,4 +1,4 @@
-asset: giphy.gif
+asset: giphy-$VERSION_NUMBER.gif
 tap: org/repo/tool.rb
 template: >
   class TestTool < Formula

--- a/test/fixtures/release-prerelease.json
+++ b/test/fixtures/release-prerelease.json
@@ -36,7 +36,7 @@
       {
         "url": "https://api.github.com/repos/toolmantim/tap-release-test-project/releases/assets/7209611",
         "id": 7209611,
-        "name": "giphy.gif",
+        "name": "giphy-2.0.0-beta.gif",
         "label": null,
         "uploader": {
           "login": "toolmantim",
@@ -63,7 +63,7 @@
         "download_count": 0,
         "created_at": "2018-05-17T12:44:59Z",
         "updated_at": "2018-05-17T12:45:16Z",
-        "browser_download_url": "https://github.com/toolmantim/tap-release-test-project/releases/download/v2.0.0-beta/giphy.gif"
+        "browser_download_url": "https://github.com/toolmantim/tap-release-test-project/releases/download/v2.0.0-beta/giphy-2.0.0-beta.gif"
       }
     ],
     "tarball_url": "https://api.github.com/repos/toolmantim/tap-release-test-project/tarball/v2.0.0-beta",

--- a/test/fixtures/release.json
+++ b/test/fixtures/release.json
@@ -36,7 +36,7 @@
       {
         "url": "https://api.github.com/repos/toolmantim/tap-release-test-project/releases/assets/7209611",
         "id": 7209611,
-        "name": "giphy.gif",
+        "name": "giphy-1.0.2.gif",
         "label": null,
         "uploader": {
           "login": "toolmantim",
@@ -63,7 +63,7 @@
         "download_count": 0,
         "created_at": "2018-05-17T12:44:59Z",
         "updated_at": "2018-05-17T12:45:16Z",
-        "browser_download_url": "https://github.com/toolmantim/tap-release-test-project/releases/download/v1.0.2/giphy.gif"
+        "browser_download_url": "https://github.com/toolmantim/tap-release-test-project/releases/download/v1.0.2/giphy-1.0.2.gif"
       }
     ],
     "tarball_url": "https://api.github.com/repos/toolmantim/tap-release-test-project/tarball/v1.0.2",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -80,7 +80,7 @@ describe('tap-release-bot', () => {
   desc "What a project"
 
   stable do
-    url "https://github.com/toolmantim/tap-release-test-project/releases/download/v1.0.2/giphy.gif"
+    url "https://github.com/toolmantim/tap-release-test-project/releases/download/v1.0.2/giphy-1.0.2.gif"
     version "v1.0.2"
     sha256 "f37fb1777c7a4f92563f0ada49f738804ff4776cde43d2f6bb819d31a169dd7b"
   end
@@ -174,7 +174,7 @@ end
   end
 
   devel do
-    url "https://github.com/toolmantim/tap-release-test-project/releases/download/v2.0.0-beta/giphy.gif"
+    url "https://github.com/toolmantim/tap-release-test-project/releases/download/v2.0.0-beta/giphy-2.0.0-beta.gif"
     version "v2.0.0-beta"
     sha256 "f37fb1777c7a4f92563f0ada49f738804ff4776cde43d2f6bb819d31a169dd7b"
   end
@@ -257,7 +257,7 @@ end
   desc "What a project"
 
   stable do
-    url "https://github.com/toolmantim/tap-release-test-project/releases/download/v1.0.2/giphy.gif"
+    url "https://github.com/toolmantim/tap-release-test-project/releases/download/v1.0.2/giphy-1.0.2.gif"
     version "v1.0.2"
     sha256 "f37fb1777c7a4f92563f0ada49f738804ff4776cde43d2f6bb819d31a169dd7b"
   end


### PR DESCRIPTION
Some releases (such as https://github.com/buildkite/cli) include version names in their asset file names. This adds `$VERSION` and `$VERSION_NUMBER` variable support to the asset name.